### PR TITLE
fixed "Invalid key or zero length key is not allowed in LMDB" error w…

### DIFF
--- a/write.js
+++ b/write.js
@@ -153,7 +153,7 @@ export function addWriteMethods(LMDBStore, { env, fixedBuffer, resetReadTxn, use
 			let endPosition;
 			try {
 				endPosition = store.writeKey(key, targetBytes, keyStartPosition);
-				if (!(keyStartPosition < endPosition) && flags != 12)
+				if (!(keyStartPosition < endPosition) && !(flags & 12))
 					throw new Error('Invalid key or zero length key is not allowed in LMDB')
 			} catch(error) {
 				targetBytes.fill(0, keyStartPosition);


### PR DESCRIPTION
…hen trying to call db.drop() on an empty child table.

Steps to reproduce:
```
export async function main() {
  const db = open({ path: '.db' })
  const table = db.openDB({ name: 'table ' })
  await table.drop()
}

main()

/*
(node:1900) UnhandledPromiseRejectionWarning: Error: Invalid key or zero length key is not allowed in LMDB
    at writeInstructions (/home/arthur/src/crawler/node_modules/lmdb/write.js:158:12)
    at LMDBStore.drop (/home/arthur/src/crawler/node_modules/lmdb/write.js:662:4)
    at /home/arthur/src/crawler/src/index.ts:37:15
    at Generator.next (<anonymous>)
    at /home/arthur/src/crawler/src/index.ts:8:71
    at new Promise (<anonymous>)
    at __awaiter (/home/arthur/src/crawler/src/index.ts:4:12)
    at main2 (/home/arthur/src/crawler/src/index.ts:44:12)
    at Object.<anonymous> (/home/arthur/src/crawler/src/index.ts:41:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
*/
```
